### PR TITLE
Fix release job to properly flatten artifact directories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,12 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: dist
-          merge-multiple: true
+
+      - name: Flatten artifact directories
+        run: |
+          cd dist
+          find . -maxdepth 2 -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} . \;
+          find . -maxdepth 1 -type d ! -name . -delete
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
The download-artifact v8 action creates nested directories for each artifact. Update the release job to flatten the directory structure so that all built archives (.tar.gz and .zip files) are in the dist/ directory and can be included in the GitHub Release.