### PR TITLE
Docker setup: add Claude binary and non-root user support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,19 @@ FROM ubuntu:latest
 # v1.2.27/opencode-linux-x64-musl.tar.gz
 ARG opencode=v1.2.27/opencode-linux-x64.tar.gz
 
-# v0.18.2/ollama-linux-amd64-rocm.tar.zst
-# v0.18.2/ollama-linux-amd64.tar.zst
-# v0.18.2/ollama-linux-arm64-jetpack5.tar.zst
-# v0.18.2/ollama-linux-arm64-jetpack6.tar.zst
-# v0.18.2/ollama-linux-arm64.tar.zst
-#ARG ollama=v0.18.2/ollama-linux-amd64.tar.zst
+# 2.1.110/linux-x64-musl/claude
+ARG claude=2.1.110/linux-x64/claude
 
 RUN apt update && \
     apt install -y curl zstd && \
-    echo "Downloading external deps..." && \
+    echo "Downloading opencode..." && \
     curl -fsSL https://github.com/anomalyco/opencode/releases/download/$opencode | gunzip -c | tar -xf - -C /usr/local/bin && \
-#    curl -fsSL https://github.com/ollama/ollama/releases/download/$ollama | zstd -d | tar -xf - -C /usr/local && \
+    echo "Downloading claude..." && \
+    curl -fsSL https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/$claude > /usr/local/bin/claude && chmod +x /usr/local/bin/claude && \
     echo "Done"
 
+# Create a non-root user with home directory
+RUN useradd -m -s /bin/bash user
+
+# Set the user as the default
+USER user

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GIT_SHA := $(shell git rev-parse --short HEAD)
 IMAGE := dmcli
 WORKSPACE ?= $(shell pwd)
+UID := $(shell id -u)
+GID := $(shell id -g)
 
 docker-build:
 	@docker build \
@@ -10,6 +12,11 @@ docker-build:
 
 docker-run:
 	@docker run --rm -it \
+		--user $(UID):$(GID) \
+		-w /workspace \
 		-v $(WORKSPACE):/workspace:rw \
+		-v dmcli-home:/home/user \
 		$(IMAGE):latest
 
+docker-clean:
+	@docker volume rm dmcli-home

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ docker-build:
 
 docker-run:
 	@docker run --rm -it \
-		-v $(WORKSPACE):/workspace:ro \
+		-v $(WORKSPACE):/workspace:rw \
 		$(IMAGE):latest
 


### PR DESCRIPTION
- Mount the workspace folder rw
- Update Dockerfile to download and install Claude binary
- Add non-root user (user) for container execution
- Update Makefile with UID/GID mapping for docker-run target
- Add workspace volume mount and home directory volume
- Add docker-clean target to remove home volume